### PR TITLE
Fix NY RPC Rule 4.4(a) citations: use actual NY rule text, not ABA model

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Fork this repo, improve the citations. Add evidence you have. File your own comp
 
 The more complaints that are filed with proper documentation, the harder they are to ignore. Every complaint becomes part of the attorney's disciplinary record regardless of outcome.
 
-### how to file with the New York State Bar
+### how to file with the New York grievance committee
 
 The Attorney Grievance Committee for the First Judicial Department handles complaints against attorneys whose offices are in New York County. **Info:** https://ww2.nycourts.gov/attorneys/grievance/complaints.shtml
 

--- a/randy_newman_bar_complaint.md
+++ b/randy_newman_bar_complaint.md
@@ -233,7 +233,7 @@ Newman's own on-camera admission that he knows direct email solicitation is proh
 
 #### New York:
 
-**[NY RPC Rule 4.4(a)](https://www.americanbar.org/groups/professional_responsibility/publications/model_rules_of_professional_conduct/rule_4_4_respect_for_rights_of_third_persons/):** In representing a client, a lawyer shall not use means that have no substantial purpose other than to embarrass, delay, or burden a third person, or use methods of obtaining evidence that violate the legal rights of such a person.
+**[NY RPC Rule 4.4(a)](https://www.law.cornell.edu/regulations/new-york/22-NYCRR-1200.4.4):** In representing a client, a lawyer shall not use means that have no substantial purpose other than to embarrass or harm a third person or use methods of obtaining evidence that violate the legal rights of such a person.
 
 **NY RPC Rule 8.4(d):** Conduct prejudicial to the administration of justice.
 
@@ -491,7 +491,7 @@ These are not isolated comments. Newman systematically uses YouTube livestreams 
 
 #### New York:
 
-**[NY RPC Rule 4.4(a)](https://www.law.cornell.edu/regulations/new-york/22-NYCRR-1200.4.4):** "In representing a client, a lawyer shall not use means that have no substantial purpose other than to embarrass, delay, or burden a third person, or use methods of obtaining evidence that violate the legal rights of such a person."
+**[NY RPC Rule 4.4(a)](https://www.law.cornell.edu/regulations/new-york/22-NYCRR-1200.4.4):** "In representing a client, a lawyer shall not use means that have no substantial purpose other than to embarrass or harm a third person or use methods of obtaining evidence that violate the legal rights of such a person."
 
 **[NY RPC Rule 3.1](https://www.law.cornell.edu/regulations/new-york/22-NYCRR-1200.3.1):** "A lawyer shall not bring or defend a proceeding, or assert or controvert an issue therein, unless there is a basis in law and fact for doing so that is not frivolous, which includes a good faith argument for an extension, modification, or reversal of existing law."
 


### PR DESCRIPTION
## Summary

- The complaint cited ABA Model Rule 4.4(a) instead of the actual New York RPC in two places. The ABA version says "embarrass, delay, or burden" while the actual NY rule (22 NYCRR 1200.0, Rule 4.4(a)) says "embarrass or harm." Fixed the quoted text and replaced the americanbar.org link with the correct law.cornell.edu/regulations/new-york link.
- Fixed README heading from "how to file with the New York State Bar" to "how to file with the New York grievance committee," since NY attorney complaints go to the court grievance committees, not a state bar.

## Changes

- `randy_newman_bar_complaint.md`: Fixed Rule 4.4(a) link and quoted text in two locations (sections #4 and #8)
- `README.md`: Corrected filing heading for New York